### PR TITLE
Expose tag filters and weighting

### DIFF
--- a/app/src/main/java/com/neologotron/app/ui/screens/MainScreen.kt
+++ b/app/src/main/java/com/neologotron/app/ui/screens/MainScreen.kt
@@ -42,6 +42,7 @@ fun MainScreen(
     val word by vm.word.collectAsState()
     val definition by vm.definition.collectAsState()
     val isFavorite by vm.isFavorite.collectAsState()
+    val activeTags by vm.activeTags.collectAsState()
     val snackbarHostState = remember { SnackbarHostState() }
     val context = LocalContext.current
 
@@ -87,6 +88,17 @@ fun MainScreen(
                 modifier = Modifier.padding(top = 8.dp),
                 textAlign = TextAlign.Center
             )
+            if (activeTags.isNotEmpty()) {
+                Text(
+                    text = stringResource(id = R.string.label_active_tags, activeTags.joinToString()),
+                    style = MaterialTheme.typography.bodyMedium,
+                    modifier = Modifier.padding(top = 8.dp),
+                    textAlign = TextAlign.Center
+                )
+                Button(onClick = { vm.clearTags() }, modifier = Modifier.padding(top = 8.dp)) {
+                    Text(text = stringResource(id = R.string.action_clear_tags))
+                }
+            }
             Button(onClick = { vm.generate() }, modifier = Modifier.padding(top = 24.dp)) {
                 Text(text = stringResource(id = R.string.action_generate))
             }

--- a/app/src/main/java/com/neologotron/app/ui/viewmodel/MainViewModel.kt
+++ b/app/src/main/java/com/neologotron/app/ui/viewmodel/MainViewModel.kt
@@ -34,6 +34,8 @@ class MainViewModel @Inject constructor(
     private val _favoriteToggled = MutableSharedFlow<Boolean>(extraBufferCapacity = 1)
     val favoriteToggled: SharedFlow<Boolean> = _favoriteToggled
 
+    val activeTags: StateFlow<Set<String>> = options.selectedTags
+
     fun generate(tags: Set<String> = options.selectedTags.value) {
         viewModelScope.launch {
             runCatching { generator.generateRandom(tags, saveToHistory = true) }
@@ -65,4 +67,6 @@ class MainViewModel @Inject constructor(
             _favoriteToggled.emit(!currentlyFav)
         }
     }
+
+    fun clearTags() { options.clear() }
 }

--- a/app/src/main/java/com/neologotron/app/ui/viewmodel/ThematicViewModel.kt
+++ b/app/src/main/java/com/neologotron/app/ui/viewmodel/ThematicViewModel.kt
@@ -20,8 +20,7 @@ class ThematicViewModel @Inject constructor(
     private val _tags = MutableStateFlow<List<String>>(emptyList())
     val tags: StateFlow<List<String>> = _tags
 
-    private val _selected = MutableStateFlow<Set<String>>(emptySet())
-    val selected: StateFlow<Set<String>> = _selected
+    val selected: StateFlow<Set<String>> = options.selectedTags
 
     init {
         viewModelScope.launch {
@@ -30,20 +29,20 @@ class ThematicViewModel @Inject constructor(
     }
 
     fun toggle(tag: String) {
-        _selected.value = _selected.value.toMutableSet().also { set ->
-            if (!set.add(tag)) set.remove(tag)
-        }
+        val current = options.selectedTags.value.toMutableSet()
+        if (!current.add(tag)) current.remove(tag)
+        options.setTags(current)
     }
 
     fun reset() {
-        _selected.value = emptySet()
+        options.clear()
     }
 
-    fun apply() { options.setTags(_selected.value) }
+    fun apply() { /* selection is applied immediately */ }
 
     fun generateAndOpen(onOpenDetail: (String) -> Unit) {
         viewModelScope.launch {
-            runCatching { generator.generateRandom(tags = _selected.value, saveToHistory = true) }
+            runCatching { generator.generateRandom(tags = options.selectedTags.value, saveToHistory = true) }
                 .onSuccess { onOpenDetail(it.word) }
         }
     }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -48,4 +48,6 @@
     <string name="about_links">En savoir plus : Logotron (Jean‑Pierre Petit), Oulipo et expérimentations littéraires.</string>
     <string name="about_version">Version: %1$s</string>
     <string name="msg_select_all_parts">Sélectionnez un préfixe, une racine et un suffixe</string>
+    <string name="label_active_tags">Tags actifs: %1$s</string>
+    <string name="action_clear_tags">Effacer les tags</string>
 </resources>


### PR DESCRIPTION
## Summary
- Expose thematic tag selection through a shared GeneratorOptionsStore
- Weight random word generation by matching tag counts across prefixes, roots and suffixes
- Surface active tags on the main screen and allow clearing the selection

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b187bb4ccc8326bf39f174a4161d48