### PR TITLE
feat: add Room migration from v5 to v6

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -80,6 +80,8 @@ dependencies {
     implementation(libs.datastorePreferences)
 
     testImplementation(libs.junit)
+    testImplementation(libs.androidxTestCore)
+    testImplementation(libs.robolectric)
     androidTestImplementation(platform(libs.composeBom))
     androidTestImplementation(libs.androidxJunit)
     androidTestImplementation(libs.espressoCore)

--- a/app/src/main/java/com/neologotron/app/data/db/AppDatabase.kt
+++ b/app/src/main/java/com/neologotron/app/data/db/AppDatabase.kt
@@ -17,7 +17,7 @@ import com.neologotron.app.data.entity.SuffixEntity
 
 @Database(
     entities = [PrefixEntity::class, RootEntity::class, SuffixEntity::class, HistoryEntity::class, DbMetaEntity::class, FavoriteEntity::class],
-    version = 5,
+    version = 6,
     exportSchema = false,
 )
 abstract class AppDatabase : RoomDatabase() {

--- a/app/src/main/java/com/neologotron/app/data/db/Migrations.kt
+++ b/app/src/main/java/com/neologotron/app/data/db/Migrations.kt
@@ -1,0 +1,33 @@
+package com.neologotron.app.data.db
+
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
+
+object Migrations {
+    val FROM_5_TO_6 =
+        object : Migration(5, 6) {
+            override fun migrate(db: SupportSQLiteDatabase) {
+                // Add nullable morph metadata columns to history table
+                db.execSQL("ALTER TABLE history ADD COLUMN prefixForm TEXT")
+                db.execSQL("ALTER TABLE history ADD COLUMN rootForm TEXT")
+                db.execSQL("ALTER TABLE history ADD COLUMN suffixForm TEXT")
+                db.execSQL("ALTER TABLE history ADD COLUMN rootGloss TEXT")
+                db.execSQL("ALTER TABLE history ADD COLUMN rootConnectorPref TEXT")
+                db.execSQL("ALTER TABLE history ADD COLUMN suffixPosOut TEXT")
+                db.execSQL("ALTER TABLE history ADD COLUMN suffixDefTemplate TEXT")
+                db.execSQL("ALTER TABLE history ADD COLUMN suffixTags TEXT")
+
+                // Add nullable morph metadata columns to favorites table
+                db.execSQL("ALTER TABLE favorites ADD COLUMN prefixForm TEXT")
+                db.execSQL("ALTER TABLE favorites ADD COLUMN rootForm TEXT")
+                db.execSQL("ALTER TABLE favorites ADD COLUMN suffixForm TEXT")
+                db.execSQL("ALTER TABLE favorites ADD COLUMN rootGloss TEXT")
+                db.execSQL("ALTER TABLE favorites ADD COLUMN rootConnectorPref TEXT")
+                db.execSQL("ALTER TABLE favorites ADD COLUMN suffixPosOut TEXT")
+                db.execSQL("ALTER TABLE favorites ADD COLUMN suffixDefTemplate TEXT")
+                db.execSQL("ALTER TABLE favorites ADD COLUMN suffixTags TEXT")
+            }
+        }
+
+    val ALL = arrayOf(FROM_5_TO_6)
+}

--- a/app/src/main/java/com/neologotron/app/data/di/DatabaseModule.kt
+++ b/app/src/main/java/com/neologotron/app/data/di/DatabaseModule.kt
@@ -16,6 +16,7 @@ import com.neologotron.app.data.dao.PrefixDao
 import com.neologotron.app.data.dao.RootDao
 import com.neologotron.app.data.dao.SuffixDao
 import com.neologotron.app.data.db.AppDatabase
+import com.neologotron.app.data.db.Migrations
 import com.neologotron.app.data.seed.SeedManager
 
 @Module
@@ -29,7 +30,7 @@ object DatabaseModule {
     ): AppDatabase {
         val db =
             Room.databaseBuilder(context, AppDatabase::class.java, "neologotron.db")
-                .fallbackToDestructiveMigration() // safe for early MVP
+                .addMigrations(*Migrations.ALL)
                 .build()
         // Seed in background on first run
         Executors.newSingleThreadExecutor().execute {

--- a/app/src/test/java/com/neologotron/app/data/MigrationTest.kt
+++ b/app/src/test/java/com/neologotron/app/data/MigrationTest.kt
@@ -1,0 +1,110 @@
+package com.neologotron.app.data
+
+import android.content.Context
+import androidx.room.Room
+import androidx.sqlite.db.SupportSQLiteDatabase
+import androidx.sqlite.db.SupportSQLiteOpenHelper
+import androidx.sqlite.db.framework.FrameworkSQLiteOpenHelperFactory
+import androidx.test.core.app.ApplicationProvider
+import com.neologotron.app.data.db.AppDatabase
+import com.neologotron.app.data.db.Migrations
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@RunWith(RobolectricTestRunner::class)
+class MigrationTest {
+    private val context: Context = ApplicationProvider.getApplicationContext()
+    private val dbName = "migration-test.db"
+
+    private fun createDatabaseV5(): SupportSQLiteOpenHelper =
+        FrameworkSQLiteOpenHelperFactory().create(
+            SupportSQLiteOpenHelper.Configuration.builder(context)
+                .name(dbName)
+                .callback(
+                    object : SupportSQLiteOpenHelper.Callback(5) {
+                        override fun onCreate(db: SupportSQLiteDatabase) {
+                            db.execSQL(
+                                "CREATE TABLE IF NOT EXISTS history (" +
+                                    "id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                                    "word TEXT NOT NULL, " +
+                                    "definition TEXT NOT NULL, " +
+                                    "decomposition TEXT NOT NULL, " +
+                                    "mode TEXT NOT NULL, " +
+                                    "timestamp INTEGER NOT NULL)",
+                            )
+                            db.execSQL(
+                                "CREATE TABLE IF NOT EXISTS favorites (" +
+                                    "id INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, " +
+                                    "word TEXT NOT NULL, " +
+                                    "definition TEXT NOT NULL, " +
+                                    "decomposition TEXT NOT NULL, " +
+                                    "mode TEXT NOT NULL, " +
+                                    "createdAt INTEGER NOT NULL)",
+                            )
+                        }
+
+                        override fun onUpgrade(
+                            db: SupportSQLiteDatabase,
+                            oldVersion: Int,
+                            newVersion: Int,
+                        ) {
+                        }
+                    },
+                )
+                .build(),
+        )
+
+    @Test
+    fun migrate5To6_preservesData() {
+        val helperV5 = createDatabaseV5()
+        val dbV5 = helperV5.writableDatabase
+        dbV5.execSQL(
+            "INSERT INTO history (word, definition, decomposition, mode, timestamp) " +
+                "VALUES ('mot','def','dec','tech',1)",
+        )
+        dbV5.execSQL(
+            "INSERT INTO favorites (word, definition, decomposition, mode, createdAt) " +
+                "VALUES ('mot','def','dec','tech',1)",
+        )
+        dbV5.close()
+
+        Room.databaseBuilder(context, AppDatabase::class.java, dbName)
+            .addMigrations(*Migrations.ALL)
+            .build()
+            .apply {
+                openHelper.writableDatabase.close()
+            }
+
+        val helperV6 =
+            FrameworkSQLiteOpenHelperFactory().create(
+                SupportSQLiteOpenHelper.Configuration.builder(context)
+                    .name(dbName)
+                    .callback(
+                        object : SupportSQLiteOpenHelper.Callback(6) {
+                            override fun onCreate(db: SupportSQLiteDatabase) {}
+
+                            override fun onUpgrade(
+                                db: SupportSQLiteDatabase,
+                                oldVersion: Int,
+                                newVersion: Int,
+                            ) {}
+                        },
+                    )
+                    .build(),
+            )
+        val db = helperV6.readableDatabase
+        val historyCursor = db.query("SELECT word, prefixForm FROM history")
+        assertTrue(historyCursor.moveToFirst())
+        assertNull(historyCursor.getString(1))
+        historyCursor.close()
+
+        val favoritesCursor = db.query("SELECT word, prefixForm FROM favorites")
+        assertTrue(favoritesCursor.moveToFirst())
+        assertNull(favoritesCursor.getString(1))
+        favoritesCursor.close()
+        db.close()
+    }
+}

--- a/app/src/test/java/com/neologotron/app/domain/generator/GeneratorRulesTest.kt
+++ b/app/src/test/java/com/neologotron/app/domain/generator/GeneratorRulesTest.kt
@@ -1,6 +1,8 @@
 package com.neologotron.app.domain.generator
 
-import org.junit.Assert.*
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Test
 
 class GeneratorRulesTest {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,8 @@ material = "1.12.0"
 room = "2.6.1"
 hiltNavigationCompose = "1.2.0"
 datastore = "1.1.1"
+androidxTestCore = "1.5.0"
+robolectric = "4.11.1"
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -55,3 +57,5 @@ roomKtx = { module = "androidx.room:room-ktx", version.ref = "room" }
 roomCompiler = { module = "androidx.room:room-compiler", version.ref = "room" }
 hiltNavigationCompose = { module = "androidx.hilt:hilt-navigation-compose", version.ref = "hiltNavigationCompose" }
 datastorePreferences = { module = "androidx.datastore:datastore-preferences", version.ref = "datastore" }
+androidxTestCore = { module = "androidx.test:core", version.ref = "androidxTestCore" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }


### PR DESCRIPTION
## Summary
- add explicit Room migration from version 5 to 6 for history and favorites metadata columns
- wire database builder to use migrations
- cover migration path with Robolectric test

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew ktlintCheck` *(fails: KtLint found code style violations in existing sources)*

------
https://chatgpt.com/codex/tasks/task_e_68b4aaa15a848326a8445068478bc25c